### PR TITLE
add soft delete variable for gcs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,7 @@ module "storage" {
   gcs_storage_class               = var.gcs_storage_class
   gcs_uniform_bucket_level_access = var.gcs_uniform_bucket_level_access
   gcs_force_destroy               = var.gcs_force_destroy
+  gcs_soft_delete_retention_days  = var.gcs_soft_delete_retention_days
 }
 
 module "gke-cluster" {

--- a/module-docs.md
+++ b/module-docs.md
@@ -101,6 +101,14 @@ Type: `bool`
 
 Default: `false`
 
+### <a name="input_gcs_soft_delete_retention_days"></a> [gcs\_soft\_delete\_retention\_days](#input\_gcs\_soft\_delete\_retention\_days)
+
+Description: Number of days to retain soft-deleted objects in Braintrust GCS buckets. During this period, deleted objects can be recovered.
+
+Type: `number`
+
+Default: `7`
+
 ### <a name="input_gcs_storage_class"></a> [gcs\_storage\_class](#input\_gcs\_storage\_class)
 
 Description: Storage class of Braintrust GCS buckets.

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -39,6 +39,10 @@ resource "google_storage_bucket" "brainstore" {
     enabled = var.gcs_versioning_enabled
   }
 
+  soft_delete_policy {
+    retention_duration_seconds = var.gcs_soft_delete_retention_days * 86400
+  }
+
   lifecycle_rule {
     condition {
       days_since_noncurrent_time = var.gcs_bucket_retention_days
@@ -82,6 +86,10 @@ resource "google_storage_bucket" "api" {
 
   versioning {
     enabled = var.gcs_versioning_enabled
+  }
+
+  soft_delete_policy {
+    retention_duration_seconds = var.gcs_soft_delete_retention_days * 86400
   }
 
   # Lifecycle rule for code-bundle path

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -51,3 +51,9 @@ variable "gcs_kms_cmek_id" {
   default     = null
 }
 
+variable "gcs_soft_delete_retention_days" {
+  type        = number
+  description = "Number of days to retain soft-deleted objects in Braintrust GCS buckets. During this period, deleted objects can be recovered."
+  default     = 7
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -192,6 +192,12 @@ variable "gcs_force_destroy" {
   default     = false
 }
 
+variable "gcs_soft_delete_retention_days" {
+  type        = number
+  description = "Number of days to retain soft-deleted objects in Braintrust GCS buckets. During this period, deleted objects can be recovered."
+  default     = 7
+}
+
 #----------------------------------------------------------------------------------------------
 # GKE Cluster (optional)
 #----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Add the option to configure the soft delete retention settings for the GCS buckets. By default it uses 7 days * 86400 which is 604800 which matches the google default setting. 