### PR TITLE
feat: add support for custom brainstore GCS lifecycle rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,7 @@ module "storage" {
   gcs_uniform_bucket_level_access = var.gcs_uniform_bucket_level_access
   gcs_force_destroy               = var.gcs_force_destroy
   gcs_soft_delete_retention_days  = var.gcs_soft_delete_retention_days
+  gcs_brainstore_lifecycle_rules  = var.gcs_brainstore_lifecycle_rules
 }
 
 module "gke-cluster" {

--- a/module-docs.md
+++ b/module-docs.md
@@ -85,6 +85,30 @@ Type: `list(string)`
 
 Default: `[]`
 
+### <a name="input_gcs_brainstore_lifecycle_rules"></a> [gcs\_brainstore\_lifecycle\_rules](#input\_gcs\_brainstore\_lifecycle\_rules)
+
+Description: Additional lifecycle rules for the brainstore GCS bucket. Allows defining custom object expiration policies for specific prefixes.
+
+Type:
+
+```hcl
+list(object({
+    action = object({
+      type          = string
+      storage_class = optional(string)
+    })
+    condition = object({
+      age                        = optional(number)
+      days_since_noncurrent_time = optional(number)
+      matches_prefix             = optional(list(string))
+      matches_suffix             = optional(list(string))
+      with_state                 = optional(string)
+    })
+  }))
+```
+
+Default: `[]`
+
 ### <a name="input_gcs_bucket_retention_days"></a> [gcs\_bucket\_retention\_days](#input\_gcs\_bucket\_retention\_days)
 
 Description: Number of days to retain objects in the Brainstore GCS buckets.

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -52,6 +52,23 @@ resource "google_storage_bucket" "brainstore" {
     }
   }
 
+  dynamic "lifecycle_rule" {
+    for_each = var.gcs_brainstore_lifecycle_rules
+    content {
+      action {
+        type          = lifecycle_rule.value.action.type
+        storage_class = lifecycle_rule.value.action.storage_class
+      }
+      condition {
+        age                        = lifecycle_rule.value.condition.age
+        days_since_noncurrent_time = lifecycle_rule.value.condition.days_since_noncurrent_time
+        matches_prefix             = lifecycle_rule.value.condition.matches_prefix
+        matches_suffix             = lifecycle_rule.value.condition.matches_suffix
+        with_state                 = lifecycle_rule.value.condition.with_state
+      }
+    }
+  }
+
   dynamic "encryption" {
     for_each = var.gcs_kms_cmek_id != null ? ["encryption"] : []
 

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -57,3 +57,21 @@ variable "gcs_soft_delete_retention_days" {
   default     = 7
 }
 
+variable "gcs_brainstore_lifecycle_rules" {
+  description = "Additional lifecycle rules for the brainstore GCS bucket. Allows defining custom object expiration policies for specific prefixes."
+  type = list(object({
+    action = object({
+      type          = string
+      storage_class = optional(string)
+    })
+    condition = object({
+      age                        = optional(number)
+      days_since_noncurrent_time = optional(number)
+      matches_prefix             = optional(list(string))
+      matches_suffix             = optional(list(string))
+      with_state                 = optional(string)
+    })
+  }))
+  default = []
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -198,6 +198,24 @@ variable "gcs_soft_delete_retention_days" {
   default     = 7
 }
 
+variable "gcs_brainstore_lifecycle_rules" {
+  description = "Additional lifecycle rules for the brainstore GCS bucket. Allows defining custom object expiration policies for specific prefixes."
+  type = list(object({
+    action = object({
+      type          = string
+      storage_class = optional(string)
+    })
+    condition = object({
+      age                        = optional(number)
+      days_since_noncurrent_time = optional(number)
+      matches_prefix             = optional(list(string))
+      matches_suffix             = optional(list(string))
+      with_state                 = optional(string)
+    })
+  }))
+  default = []
+}
+
 #----------------------------------------------------------------------------------------------
 # GKE Cluster (optional)
 #----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Resolved #7 

Add gcs_brainstore_lifecycle_rules variable to allow users to define custom lifecycle rules for the brainstore GCS bucket. This enables prefix-specific object expiration policies without requiring ClickOps.

Changes:
- Add gcs_brainstore_lifecycle_rules variable to root variables.tf
- Add gcs_brainstore_lifecycle_rules variable to modules/storage/variables.tf
- Add dynamic lifecycle_rule block to modules/storage/main.tf
- Pass variable through module call in main.tf

Example usage:
```
gcs_brainstore_lifecycle_rules = [ 
    { 
        action = { type = "Delete" } 
        condition = { age = 17 matches_prefix = ["brainstore/wal/object-store-objects/"] }
    }
 ]
```