### PR TITLE
Add Token Creator IAM Permissions

### DIFF
--- a/modules/gke-iam/main.tf
+++ b/modules/gke-iam/main.tf
@@ -29,6 +29,12 @@ resource "google_service_account_iam_binding" "braintrust_workload_identity" {
   ]
 }
 
+resource "google_service_account_iam_member" "braintrust_token_creator" {
+  service_account_id = google_service_account.braintrust.id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.braintrust.email}"
+}
+
 resource "google_storage_bucket_iam_member" "braintrust_api_api_bucket_gcs_object_admin" {
   bucket = var.braintrust_api_bucket_id
   role   = "roles/storage.objectAdmin"


### PR DESCRIPTION
Support for Native GCS auth has been merged into the data plane, however additional IAM permissions are required. This PR adds support for GCS authentication by granting the Braintrust service account the serviceAccountTokenCreator role on itself. This allows the service account to generate its own access tokens, which is required for certain GCS authentication workflows. 