### PR TITLE
Add API pod Workload Identity binding for Data Plane 2.0 GCS access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Braintrust GCP Data Plane - Terraform Module
+
+This is a Terraform module that provisions GCP infrastructure for the Braintrust hybrid data plane on Google Kubernetes Engine.
+
+## Module Structure
+
+```
+├── main.tf, variables.tf, outputs.tf, versions.tf   # Root module - orchestrates submodules
+├── modules/
+│   ├── database/       # Cloud SQL (PostgreSQL)
+│   ├── gke-cluster/    # GKE cluster (Standard or Autopilot)
+│   ├── gke-iam/        # IAM, Workload Identity, HMAC keys
+│   ├── kms/            # Cloud KMS encryption keys
+│   ├── redis/          # Memorystore (Redis)
+│   ├── storage/        # GCS buckets
+│   └── vpc/            # VPC, subnets, private service connections
+├── examples/
+│   └── braintrust-data-plane/   # Production example
+└── mise.toml                    # Tool versions and tasks (terraform, tflint)
+```
+
+### Key architecture concepts
+
+- **Pure infrastructure module.** This module creates VPC, GKE, Cloud SQL, Redis, GCS, and IAM resources. It does not manage application-level configuration (environment variables, image tags, etc.). All application config lives in the Helm chart deployed on top of this infrastructure.
+- **`deployment_name`** prefixes all resource names and must be unique per deployment in the same GCP project.
+- **Workload Identity** is used to grant GKE pods access to GCP resources. The `gke-iam` module creates GCP service accounts and binds them to Kubernetes service accounts via `roles/iam.workloadIdentityUser`.
+
+## Critical Safety Constraints
+
+### Workload Identity Bindings
+
+The `gke-iam` module uses `google_service_account_iam_binding`, which is **authoritative** - it sets the complete list of members for the given role. If members are added manually outside Terraform for the same role, they will be removed on the next apply.
+
+Both the `brainstore` and `braintrust-api` Kubernetes service accounts must be bound to the brainstore GCP service account. The API pod accesses GCS directly for endpoints like `/brainstore/object-data-exists`.
+
+### Database Encryption Cosmetic Drift
+
+GCP API returns `database_encryption.state` as `ALL_OBJECTS_ENCRYPTION_ENABLED` but Terraform writes `ENCRYPTED`. This causes a no-op GKE cluster update (10-15 min) on every apply. A `lifecycle { ignore_changes }` block is the recommended fix but has not been applied yet.
+
+### First-Deploy Timing Issue
+
+The module may fail on the first `terraform apply` due to a timing issue with the VPC private service connection. Re-running `terraform apply` typically resolves it.
+
+## Development
+
+Tool versions are managed via `mise.toml`:
+
+```bash
+mise install        # Install terraform, tflint
+mise run setup      # Install pre-commit hooks
+mise run lint       # terraform fmt + tflint
+mise run validate   # terraform init + validate
+```
+
+Pre-commit hooks run automatically on commit. Run `mise run lint` to check before committing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,6 @@ The `gke-iam` module uses `google_service_account_iam_binding`, which is **autho
 
 Both the `brainstore` and `braintrust-api` Kubernetes service accounts must be bound to the brainstore GCP service account. The API pod accesses GCS directly for endpoints like `/brainstore/object-data-exists`.
 
-### Database Encryption Cosmetic Drift
-
-GCP API returns `database_encryption.state` as `ALL_OBJECTS_ENCRYPTION_ENABLED` but Terraform writes `ENCRYPTED`. This causes a no-op GKE cluster update (10-15 min) on every apply. A `lifecycle { ignore_changes }` block is the recommended fix but has not been applied yet.
-
 ### First-Deploy Timing Issue
 
 The module may fail on the first `terraform apply` due to a timing issue with the VPC private service connection. Re-running `terraform apply` typically resolves it.

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -135,15 +135,17 @@ resource "google_sql_database_instance" "braintrust" {
 }
 
 resource "google_sql_user" "braintrust" {
-  name     = "postgres"
-  instance = google_sql_database_instance.braintrust.name
-  password = random_password.postgres_password.result
+  name            = "postgres"
+  instance        = google_sql_database_instance.braintrust.name
+  password        = random_password.postgres_password.result
+  deletion_policy = var.postgres_deletion_protection ? null : "ABANDON"
 }
 
 resource "google_sql_user" "braintrust_iam" {
-  name     = "${var.deployment_name}-braintrust@${data.google_client_config.current.project}.iam"
-  instance = google_sql_database_instance.braintrust.name
-  type     = "CLOUD_IAM_SERVICE_ACCOUNT"
+  name            = "${var.deployment_name}-braintrust@${data.google_client_config.current.project}.iam"
+  instance        = google_sql_database_instance.braintrust.name
+  type            = "CLOUD_IAM_SERVICE_ACCOUNT"
+  deletion_policy = var.postgres_deletion_protection ? null : "ABANDON"
 }
 
 #----------------------------------------------------------------------------------------------

--- a/modules/gke-iam/main.tf
+++ b/modules/gke-iam/main.tf
@@ -89,8 +89,8 @@ resource "google_service_account_iam_binding" "brainstore_workload_identity" {
   role               = "roles/iam.workloadIdentityUser"
 
   members = [
-    "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.brainstore_kube_svc_account}]",
-    "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.braintrust_kube_svc_account}]",
+    "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.brainstore_kube_svc_account}]", # brainstore pods
+    "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.braintrust_kube_svc_account}]", # API pod (needs GCS access for 2.0+)
   ]
 }
 

--- a/modules/gke-iam/main.tf
+++ b/modules/gke-iam/main.tf
@@ -89,7 +89,8 @@ resource "google_service_account_iam_binding" "brainstore_workload_identity" {
   role               = "roles/iam.workloadIdentityUser"
 
   members = [
-    "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.brainstore_kube_svc_account}]"
+    "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.brainstore_kube_svc_account}]",
+    "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.braintrust_kube_svc_account}]",
   ]
 }
 

--- a/modules/gke-iam/main.tf
+++ b/modules/gke-iam/main.tf
@@ -90,7 +90,7 @@ resource "google_service_account_iam_binding" "brainstore_workload_identity" {
 
   members = [
     "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.brainstore_kube_svc_account}]", # brainstore pods
-    "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.braintrust_kube_svc_account}]", # API pod (needs GCS access for 2.0+)
+    "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.braintrust_kube_svc_account}]", # API pod(s)
   ]
 }
 


### PR DESCRIPTION
Data Plane 2.0 introduces API pod endpoints that access GCS directly. This update grants the braintrust-api Kubernetes service account Workload Identity access to the brainstore GCP service account, alongside the existing brainstore binding. No action is required when upgrading to this module version.

**What's new**

- The `braintrust-api` K8s service account is now included in the brainstore Workload Identity binding (`roles/iam.workloadIdentityUser`). This must be applied before
upgrading to Data Plane 2.0 on GKE.
- Added `AGENTS.md` with module structure and safety constraints for contributors.
- SQL user teardown fix: When `postgres_deletion_protection = false`, SQL users are abandoned on destroy instead of explicitly deleted, avoiding the _"role cannot be dropped because some objects depend on it"_ error during terraform destroy

**Upgrade guide**

For full upgrade instructions, see the [Self-Hosting documentation](https://www.braintrust.dev/docs/admin/self-hosting) upgrade section.