### PR TITLE
add service account impersonation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Braintrust Terraform Google Module
 
-This module is currently beta status. There may be breaking changes that require a complete deletion and re-deployment
-
 This module is used to create the VPC, Databases, Redis, Storage, IAM, and associated resources for the self-hosted Braintrust data plane on Google using Google Kubernetes Engine.
 
 ## Module Configuration
@@ -36,9 +34,6 @@ This section is only relevant if you are a contributor who wants to make changes
 
 ## TODO
 
-- Logging is configured to use the default project log sink, need to determine if a custom log sink will be needed.
 - This module will fail the first time it is deployed due to timing issue with the private connection for the VPC. Exploring ways to fix this still without adding a module depends on which causes issues.
 - Explore customer support module like AWS module
-- Explore optional cloud-run module as front end for braintrust api frontend
 - Explore using Terraform to enable google services instead of CLI/GUI
-- Test support for GKE auto pilot nodes

--- a/main.tf
+++ b/main.tf
@@ -76,11 +76,12 @@ module "gke-cluster" {
 module "gke-iam" {
   source = "./modules/gke-iam"
 
-  deployment_name             = var.deployment_name
-  braintrust_kube_namespace   = var.braintrust_kube_namespace
-  braintrust_kube_svc_account = var.braintrust_kube_svc_account
-  brainstore_kube_svc_account = var.brainstore_kube_svc_account
-  braintrust_api_bucket_id    = module.storage.api_bucket_name
-  brainstore_gcs_bucket_id    = module.storage.brainstore_bucket_name
-  braintrust_hmac_key_enabled = var.braintrust_hmac_key_enabled
+  deployment_name                  = var.deployment_name
+  braintrust_kube_namespace        = var.braintrust_kube_namespace
+  braintrust_kube_svc_account      = var.braintrust_kube_svc_account
+  brainstore_kube_svc_account      = var.brainstore_kube_svc_account
+  braintrust_api_bucket_id         = module.storage.api_bucket_name
+  brainstore_gcs_bucket_id         = module.storage.brainstore_bucket_name
+  braintrust_hmac_key_enabled      = var.braintrust_hmac_key_enabled
+  brainstore_impersonation_targets = var.brainstore_impersonation_targets
 }

--- a/modules/gke-iam/main.tf
+++ b/modules/gke-iam/main.tf
@@ -116,3 +116,11 @@ resource "google_storage_bucket_iam_member" "brainstore_api_bucket_gcs_reader" {
   role   = "roles/storage.legacyBucketReader"
   member = "serviceAccount:${google_service_account.brainstore.email}"
 }
+
+resource "google_service_account_iam_member" "brainstore_impersonation_target" {
+  for_each = toset(var.brainstore_impersonation_targets)
+
+  service_account_id = each.value
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.brainstore.email}"
+}

--- a/modules/gke-iam/variables.tf
+++ b/modules/gke-iam/variables.tf
@@ -43,3 +43,9 @@ variable "braintrust_hmac_key_enabled" {
   description = "Whether to enable HMAC keys for Braintrust API."
   default     = true
 }
+
+variable "brainstore_impersonation_targets" {
+  type        = list(string)
+  description = "Full resource names of service accounts (same or other projects) that the brainstore service account can impersonate via roles/iam.serviceAccountTokenCreator. Format: projects/{project_id}/serviceAccounts/{email}"
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -333,9 +333,15 @@ variable "brainstore_kube_svc_account" {
   default     = "brainstore"
 }
 
-# API container doesn't support GCS native storage integration yet, so we use HMAC keys instead. 
+# With data plane 2.0.0 and later native auth can be used instead of HMAC keys.
 variable "braintrust_hmac_key_enabled" {
   type        = bool
   description = "Whether to enable HMAC keys for Braintrust API."
   default     = true
+}
+
+variable "brainstore_impersonation_targets" {
+  type        = list(string)
+  description = "Full resource names of service accounts (same or other projects) that the brainstore service account can impersonate via roles/iam.serviceAccountTokenCreator. Format: projects/{project_id}/serviceAccounts/{email}"
+  default     = []
 }


### PR DESCRIPTION
With data plane 2.1.0 the export feature has been moved into Brainstore. This also supports GCS buckets when the data plane is deployed on GCP. 

An existing Service Account needs to be passed in that allows the brainstore service account to impersonate that service account. 