### PR TITLE
Add brainstore-cache lifecycle rule to API bucketFix storage paths

### DIFF
--- a/modules/gke-iam/variables.tf
+++ b/modules/gke-iam/variables.tf
@@ -29,7 +29,7 @@ variable "brainstore_kube_svc_account" {
 
 variable "braintrust_api_bucket_id" {
   type        = string
-  description = "The ID of the GCS bucket for Braintrust API (contains code-bundle/ and response/ paths)."
+  description = "The ID of the GCS bucket for Braintrust API (contains code-bundle and brainstore-cache paths)."
 }
 
 variable "brainstore_gcs_bucket_id" {

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -112,7 +112,7 @@ resource "google_storage_bucket" "brainstore" {
 }
 
 #----------------------------------------------------------------------------------------------
-# Google cloud storage (GCS) bucket - api (combines code-bundle and response)
+# Google cloud storage (GCS) bucket - api (combines code-bundle and brainstore-cache)
 #----------------------------------------------------------------------------------------------
 resource "google_storage_bucket" "api" {
   name                        = "${var.deployment_name}-api-${random_id.gcs_suffix.hex}"
@@ -147,7 +147,7 @@ resource "google_storage_bucket" "api" {
     }
   }
 
-  # Lifecycle rule for code-bundle path
+  # Lifecycle rule for code-bundle path (API layer writes here)
   lifecycle_rule {
     condition {
       days_since_noncurrent_time = var.gcs_bucket_retention_days
@@ -158,11 +158,22 @@ resource "google_storage_bucket" "api" {
     }
   }
 
-  # Lifecycle rule for response path
+  # Lifecycle rule for response path (API layer writes here)
   lifecycle_rule {
     condition {
       age            = 1
       matches_prefix = ["response/"]
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  # Lifecycle rule for brainstore-cache path (Brainstore writes here, ephemeral cache)
+  lifecycle_rule {
+    condition {
+      age            = 1
+      matches_prefix = ["brainstore-cache/"]
     }
     action {
       type = "Delete"


### PR DESCRIPTION
- Adds lifecycle rule for `brainstore-cache/` prefix on the API GCS bucket (1-day TTL, matching the existing `response/` rule)
- Updates comments to reflect current bucket path conventions

The `brainstore-cache/` prefix is used by Brainstore for ephemeral response cache data. Without this rule, stale cache objects accumulate indefinitely.

No infrastructure changes to existing buckets beyond the new lifecycle rule.