### PR TITLE
Add labels to be passed into all resources that support labels

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,12 +11,14 @@ module "kms" {
   source = "./modules/kms"
 
   deployment_name = var.deployment_name
+  custom_labels   = var.custom_labels
 }
 
 module "database" {
   source = "./modules/database"
 
   deployment_name              = var.deployment_name
+  custom_labels                = var.custom_labels
   postgres_network             = var.create_vpc ? module.vpc[0].network_self_link : var.existing_network_self_link
   postgres_kms_cmek_id         = module.kms.kms_key_id
   postgres_version             = var.postgres_version
@@ -33,6 +35,7 @@ module "redis" {
   source = "./modules/redis"
 
   deployment_name      = var.deployment_name
+  custom_labels        = var.custom_labels
   redis_network        = var.create_vpc ? module.vpc[0].network_self_link : var.existing_network_self_link
   redis_kms_cmek_id    = module.kms.kms_key_id
   redis_version        = var.redis_version
@@ -43,6 +46,7 @@ module "storage" {
   source = "./modules/storage"
 
   deployment_name                       = var.deployment_name
+  custom_labels                         = var.custom_labels
   gcs_kms_cmek_id                       = module.kms.kms_key_id
   gcs_additional_allowed_origins        = var.gcs_additional_allowed_origins
   gcs_bucket_retention_days             = var.gcs_bucket_retention_days
@@ -60,6 +64,7 @@ module "gke-cluster" {
   count  = var.deploy_gke_cluster ? 1 : 0
 
   deployment_name                    = var.deployment_name
+  custom_labels                      = var.custom_labels
   gke_network                        = var.create_vpc ? module.vpc[0].network_self_link : var.existing_network_self_link
   gke_subnetwork                     = var.create_vpc ? module.vpc[0].subnet_self_link : var.existing_subnet_self_link
   gke_control_plane_cidr             = var.gke_control_plane_cidr

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -1,7 +1,7 @@
 locals {
-  common_labels = {
+  common_labels = merge(var.custom_labels, {
     braintrustdeploymentname = var.deployment_name
-  }
+  })
   postgres_username = "postgres"
   postgres_password = random_password.postgres_password.result
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -6,6 +6,12 @@ variable "deployment_name" {
   type        = string
 }
 
+variable "custom_labels" {
+  type        = map(string)
+  description = "Optional labels to apply to all resources that support labels."
+  default     = {}
+}
+
 #----------------------------------------------------------------------------------------------
 # Cloud SQL for PostgreSQL
 #----------------------------------------------------------------------------------------------

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -1,6 +1,12 @@
 #----------------------------------------------------------------------------------------------
 # Common
 #----------------------------------------------------------------------------------------------
+locals {
+  common_labels = merge(var.custom_labels, {
+    braintrustdeploymentname = var.deployment_name
+  })
+}
+
 data "google_client_config" "current" {}
 
 data "google_project" "current" {}
@@ -24,6 +30,8 @@ resource "google_container_cluster" "braintrust_autopilot" {
   subnetwork = var.gke_subnetwork
 
   deletion_protection = var.gke_deletion_protection
+
+  resource_labels = local.common_labels
 
   # Private cluster configuration
   dynamic "private_cluster_config" {

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -6,6 +6,12 @@ variable "deployment_name" {
   type        = string
 }
 
+variable "custom_labels" {
+  type        = map(string)
+  description = "Optional labels to apply to all resources that support labels."
+  default     = {}
+}
+
 #----------------------------------------------------------------------------------------------
 # GKE Cluster
 #----------------------------------------------------------------------------------------------

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -2,9 +2,9 @@
 # Common
 #----------------------------------------------------------------------------------------------
 locals {
-  common_labels = {
+  common_labels = merge(var.custom_labels, {
     braintrustdeploymentname = var.deployment_name
-  }
+  })
 }
 
 data "google_client_config" "current" {}

--- a/modules/kms/variables.tf
+++ b/modules/kms/variables.tf
@@ -5,3 +5,9 @@ variable "deployment_name" {
   description = "Name of the deployment. Used to prefix resource names."
   type        = string
 }
+
+variable "custom_labels" {
+  type        = map(string)
+  description = "Optional labels to apply to all resources that support labels."
+  default     = {}
+}

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -2,9 +2,9 @@
 # Common
 #----------------------------------------------------------------------------------------------
 locals {
-  common_labels = {
+  common_labels = merge(var.custom_labels, {
     braintrustdeploymentname = var.deployment_name
-  }
+  })
 }
 
 data "google_project" "current" {}

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -6,6 +6,12 @@ variable "deployment_name" {
   type        = string
 }
 
+variable "custom_labels" {
+  type        = map(string)
+  description = "Optional labels to apply to all resources that support labels."
+  default     = {}
+}
+
 #----------------------------------------------------------------------------------------------
 # Redis
 #----------------------------------------------------------------------------------------------

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -11,9 +11,9 @@ locals {
 
   all_origins = concat(local.default_origins, var.gcs_additional_allowed_origins)
 
-  common_labels = {
+  common_labels = merge(var.custom_labels, {
     braintrustdeploymentname = var.deployment_name
-  }
+  })
 }
 
 data "google_project" "current" {}

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -6,6 +6,12 @@ variable "deployment_name" {
   type        = string
 }
 
+variable "custom_labels" {
+  type        = map(string)
+  description = "Optional labels to apply to all resources that support labels."
+  default     = {}
+}
+
 #----------------------------------------------------------------------------------------------
 # GCS
 #----------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,25 @@ variable "deployment_name" {
   }
 }
 
+variable "custom_labels" {
+  type        = map(string)
+  description = "Optional labels to apply to all resources that support labels."
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.custom_labels :
+      can(regex("^[a-z][a-z0-9_-]{0,62}$", k)) && can(regex("^[a-z0-9_-]{0,63}$", v))
+    ])
+    error_message = "Label keys must start with a lowercase letter and contain only lowercase letters, numbers, underscores, and dashes (max 63 chars). Values must contain only lowercase letters, numbers, underscores, and dashes (max 63 chars)."
+  }
+
+  validation {
+    condition     = length(var.custom_labels) <= 64
+    error_message = "A maximum of 64 custom labels are allowed."
+  }
+}
+
 #----------------------------------------------------------------------------------------------
 # VPC
 #----------------------------------------------------------------------------------------------
@@ -342,6 +361,6 @@ variable "braintrust_hmac_key_enabled" {
 
 variable "brainstore_impersonation_targets" {
   type        = list(string)
-  description = "Full resource names of service accounts (same or other projects) that the brainstore service account can impersonate via roles/iam.serviceAccountTokenCreator. Format: projects/{project_id}/serviceAccounts/{email}"
+  description = "Full resource names of service accounts (same or other projects) that the brainstore service account can impersonate via roles/iam.serviceAccountTokenCreator. Format: projects/{project_id}/serviceAccounts/{email}. Only required if you are not granting IAM access to the brainstore service account yourself. Note: the principal running this Terraform deployment must have permission to manage IAM policies on the target service accounts (e.g. roles/iam.serviceAccountAdmin or roles/resourcemanager.projectIamAdmin)."
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -35,8 +35,8 @@ variable "custom_labels" {
   }
 
   validation {
-    condition     = length(var.custom_labels) <= 64
-    error_message = "A maximum of 64 custom labels are allowed."
+    condition     = length(var.custom_labels) <= 63
+    error_message = "A maximum of 63 custom labels are allowed."
   }
 }
 


### PR DESCRIPTION
With the variable `custom_labels`, can pass in a map of variables that will be applied to all GCP resources that support labels. Reason for this as the google providers label feature misses some resources.