### PR TITLE
Add configurable IP variables for private services & pod ranges 

### DIFF
--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -23,6 +23,7 @@ module "braintrust-data-plane" {
   #
   # Private Service Access range for Cloud SQL and Memorystore. Defaults to a Google-selected /16.
   # Set these if you need the private services peering range to avoid overlap with existing networks.
+  # Smaller ranges are supported, but reduce future expansion headroom.
   # Changing this after deployment can require rebuilding dependent resources.
   # private_service_access_prefix_length = 16
   # private_service_access_address       = "10.10.0.0"
@@ -34,9 +35,11 @@ module "braintrust-data-plane" {
   # gke_control_plane_authorized_cidrs = null # Allow all IPs to access the control plane
   # gke_enable_private_endpoint = false # Make sure the control plane endpoint is public
   # gke_control_plane_cidr = "10.0.1.0/28" # CIDR block for the control plane if it's Private
-  # Optional GKE Pod and Service IP ranges. Set these if you need to control the secondary ranges
+  # Optional GKE Pod and Service IP ranges. Set these only if you need to control the secondary ranges
   # used by the cluster, especially to avoid overlap with peered VPCs or corporate networks.
-  # You can either provide CIDR blocks, netmask sizes such as "/20", or existing subnet secondary range names.
+  # Most deployments should leave the Service range unset unless they intentionally need a custom Service CIDR.
+  # You can either provide CIDR blocks, netmask sizes such as "/20", or secondary range names
+  # that already exist on the subnet.
   # Do not set both forms for the same range type. Changing these after deployment is disruptive.
   # gke_pods_ipv4_cidr_block = "10.20.0.0/20"
   # gke_services_ipv4_cidr_block = "10.30.0.0/22"

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -20,6 +20,12 @@ module "braintrust-data-plane" {
 
   # The CIDR range for the subnet to deploy resources to.
   # subnet_cidr_range = "10.0.0.0/24"
+  #
+  # Private Service Access range for Cloud SQL and Memorystore. Defaults to a Google-selected /16.
+  # Set these if you need the private services peering range to avoid overlap with existing networks.
+  # Changing this after deployment can require rebuilding dependent resources.
+  # private_service_access_prefix_length = 16
+  # private_service_access_address       = "10.10.0.0"
 
   ### GKE Cluster configuration
   # Note: By default we deploy a GKE cluster. You must set deploy_gke_cluster to false to not deploy a GKE cluster, if you will provide your own GKE cluster.
@@ -28,6 +34,14 @@ module "braintrust-data-plane" {
   # gke_control_plane_authorized_cidrs = null # Allow all IPs to access the control plane
   # gke_enable_private_endpoint = false # Make sure the control plane endpoint is public
   # gke_control_plane_cidr = "10.0.1.0/28" # CIDR block for the control plane if it's Private
+  # Optional GKE Pod and Service IP ranges. Set these if you need to control the secondary ranges
+  # used by the cluster, especially to avoid overlap with peered VPCs or corporate networks.
+  # You can either provide CIDR blocks/netmask sizes or existing subnet secondary range names.
+  # Do not set both forms for the same range type. Changing these after deployment is disruptive.
+  # gke_pods_ipv4_cidr_block = "/20"
+  # gke_services_ipv4_cidr_block = "/22"
+  # gke_pods_secondary_range_name = "braintrust-pods"
+  # gke_services_secondary_range_name = "braintrust-services"
 
   ### Database configuration
   # postgres_version = "POSTGRES_17"

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -36,10 +36,10 @@ module "braintrust-data-plane" {
   # gke_control_plane_cidr = "10.0.1.0/28" # CIDR block for the control plane if it's Private
   # Optional GKE Pod and Service IP ranges. Set these if you need to control the secondary ranges
   # used by the cluster, especially to avoid overlap with peered VPCs or corporate networks.
-  # You can either provide CIDR blocks/netmask sizes or existing subnet secondary range names.
+  # You can either provide CIDR blocks, netmask sizes such as "/20", or existing subnet secondary range names.
   # Do not set both forms for the same range type. Changing these after deployment is disruptive.
-  # gke_pods_ipv4_cidr_block = "/20"
-  # gke_services_ipv4_cidr_block = "/22"
+  # gke_pods_ipv4_cidr_block = "10.20.0.0/20"
+  # gke_services_ipv4_cidr_block = "10.30.0.0/22"
   # gke_pods_secondary_range_name = "braintrust-pods"
   # gke_services_secondary_range_name = "braintrust-services"
 

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,9 @@ module "vpc" {
   deployment_name   = var.deployment_name
   vpc_name          = var.vpc_name
   subnet_cidr_range = var.subnet_cidr_range
+
+  private_service_access_prefix_length = var.private_service_access_prefix_length
+  private_service_access_address       = var.private_service_access_address
 }
 
 module "kms" {
@@ -68,6 +71,10 @@ module "gke-cluster" {
   gke_network                        = var.create_vpc ? module.vpc[0].network_self_link : var.existing_network_self_link
   gke_subnetwork                     = var.create_vpc ? module.vpc[0].subnet_self_link : var.existing_subnet_self_link
   gke_control_plane_cidr             = var.gke_control_plane_cidr
+  gke_pods_ipv4_cidr_block           = var.gke_pods_ipv4_cidr_block
+  gke_pods_secondary_range_name      = var.gke_pods_secondary_range_name
+  gke_services_ipv4_cidr_block       = var.gke_services_ipv4_cidr_block
+  gke_services_secondary_range_name  = var.gke_services_secondary_range_name
   gke_control_plane_authorized_cidrs = var.gke_control_plane_authorized_cidrs
   gke_enable_master_global_access    = var.gke_enable_master_global_access
   gke_cluster_is_private             = var.gke_cluster_is_private

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -33,6 +33,22 @@ resource "google_container_cluster" "braintrust_autopilot" {
 
   resource_labels = local.common_labels
 
+  dynamic "ip_allocation_policy" {
+    for_each = (
+      var.gke_pods_ipv4_cidr_block != null ||
+      var.gke_pods_secondary_range_name != null ||
+      var.gke_services_ipv4_cidr_block != null ||
+      var.gke_services_secondary_range_name != null
+    ) ? [1] : []
+
+    content {
+      cluster_ipv4_cidr_block       = var.gke_pods_ipv4_cidr_block
+      cluster_secondary_range_name  = var.gke_pods_secondary_range_name
+      services_ipv4_cidr_block      = var.gke_services_ipv4_cidr_block
+      services_secondary_range_name = var.gke_services_secondary_range_name
+    }
+  }
+
   # Private cluster configuration
   dynamic "private_cluster_config" {
     for_each = var.gke_cluster_is_private ? [1] : []

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -55,6 +55,40 @@ variable "gke_control_plane_cidr" {
   default     = "10.0.1.0/28"
 }
 
+variable "gke_pods_ipv4_cidr_block" {
+  type        = string
+  description = "Optional CIDR block or netmask size for GKE Pod IPs. For example, '10.20.0.0/20' or '/20'. Cannot be set with gke_pods_secondary_range_name. Choose this carefully before first deployment; changing GKE secondary ranges later is disruptive."
+  default     = null
+
+  validation {
+    condition     = var.gke_pods_ipv4_cidr_block == null || var.gke_pods_secondary_range_name == null
+    error_message = "`gke_pods_ipv4_cidr_block` cannot be set when `gke_pods_secondary_range_name` is set."
+  }
+}
+
+variable "gke_pods_secondary_range_name" {
+  type        = string
+  description = "Optional name of an existing subnet secondary range to use for GKE Pod IPs. Cannot be set with gke_pods_ipv4_cidr_block. Use this when you want GKE to consume a pre-planned secondary range."
+  default     = null
+}
+
+variable "gke_services_ipv4_cidr_block" {
+  type        = string
+  description = "Optional CIDR block or netmask size for GKE Service IPs. For example, '10.30.0.0/22' or '/22'. Cannot be set with gke_services_secondary_range_name. Choose this carefully before first deployment; changing GKE secondary ranges later is disruptive."
+  default     = null
+
+  validation {
+    condition     = var.gke_services_ipv4_cidr_block == null || var.gke_services_secondary_range_name == null
+    error_message = "`gke_services_ipv4_cidr_block` cannot be set when `gke_services_secondary_range_name` is set."
+  }
+}
+
+variable "gke_services_secondary_range_name" {
+  type        = string
+  description = "Optional name of an existing subnet secondary range to use for GKE Service IPs. Cannot be set with gke_services_ipv4_cidr_block. Use this when you want GKE to consume a pre-planned secondary range."
+  default     = null
+}
+
 variable "gke_control_plane_authorized_cidrs" {
   type        = list(string)
   description = "List of CIDR blocks authorized to access the GKE control plane. If not provided, allows all IPs (for public clusters)."

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -68,13 +68,13 @@ variable "gke_pods_ipv4_cidr_block" {
 
 variable "gke_pods_secondary_range_name" {
   type        = string
-  description = "Optional name of an existing subnet secondary range to use for GKE Pod IPs. Cannot be set with gke_pods_ipv4_cidr_block. Use this when you want GKE to consume a pre-planned secondary range."
+  description = "Optional name of a secondary range that already exists on the selected subnet for GKE Pod IPs. This variable does not create the range. Cannot be set with gke_pods_ipv4_cidr_block."
   default     = null
 }
 
 variable "gke_services_ipv4_cidr_block" {
   type        = string
-  description = "Optional CIDR block or netmask size for GKE Service IPs. For example, '10.30.0.0/22' or '/22'. Cannot be set with gke_services_secondary_range_name. Choose this carefully before first deployment; changing GKE secondary ranges later is disruptive."
+  description = "Optional CIDR block or netmask size for GKE Service IPs. Most deployments should leave this unset unless they intentionally need a custom Service CIDR. For example, '10.30.0.0/22' or '/22'. Cannot be set with gke_services_secondary_range_name. Choose this carefully before first deployment; changing GKE secondary ranges later is disruptive."
   default     = null
 
   validation {
@@ -85,7 +85,7 @@ variable "gke_services_ipv4_cidr_block" {
 
 variable "gke_services_secondary_range_name" {
   type        = string
-  description = "Optional name of an existing subnet secondary range to use for GKE Service IPs. Cannot be set with gke_services_ipv4_cidr_block. Use this when you want GKE to consume a pre-planned secondary range."
+  description = "Optional name of a secondary range that already exists on the selected subnet for GKE Service IPs. This variable does not create the range. Most deployments should leave this unset unless they intentionally need a custom Service CIDR. Cannot be set with gke_services_ipv4_cidr_block."
   default     = null
 }
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -39,7 +39,8 @@ resource "google_compute_global_address" "private_ip_address" {
   name          = "${var.deployment_name}-private-ip-address"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
-  prefix_length = 16
+  address       = var.private_service_access_address
+  prefix_length = var.private_service_access_prefix_length
   network       = google_compute_network.vpc.id
 }
 

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -18,3 +18,19 @@ variable "subnet_cidr_range" {
   description = "The IP address range of the subnet in CIDR notation"
   type        = string
 }
+
+variable "private_service_access_prefix_length" {
+  description = "Prefix length for the Private Service Access range used by Cloud SQL and Memorystore. Must be 24 or lower, where lower values create larger ranges. Choose this carefully before first deployment; changing Private Service Access ranges later can require rebuilding dependent resources."
+  type        = number
+
+  validation {
+    condition     = var.private_service_access_prefix_length >= 8 && var.private_service_access_prefix_length <= 24
+    error_message = "`private_service_access_prefix_length` must be between 8 and 24 inclusive."
+  }
+}
+
+variable "private_service_access_address" {
+  description = "Optional starting address for the Private Service Access range used by Cloud SQL and Memorystore. If null, Google selects an available range. Set this when you need to avoid overlap with existing VPCs, peering, or corporate networks."
+  type        = string
+  default     = null
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -20,7 +20,7 @@ variable "subnet_cidr_range" {
 }
 
 variable "private_service_access_prefix_length" {
-  description = "Prefix length for the Private Service Access range used by Cloud SQL and Memorystore. Must be 24 or lower, where lower values create larger ranges. Choose this carefully before first deployment; changing Private Service Access ranges later can require rebuilding dependent resources."
+  description = "Prefix length for the Private Service Access range used by Cloud SQL and Memorystore. Valid values are 8 through 24: lower prefix lengths create larger ranges, while higher prefix lengths create smaller ranges. Smaller ranges are supported, but choose the size based on the customer's networking requirements because they reduce future expansion headroom. Choose this carefully before first deployment; changing Private Service Access ranges later can require rebuilding dependent resources."
   type        = number
 
   validation {

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "subnet_cidr_range" {
 }
 
 variable "private_service_access_prefix_length" {
-  description = "Prefix length for the Private Service Access range used by Cloud SQL and Memorystore (when create_vpc is true). Must be 24 or lower, where lower values create larger ranges. Choose this carefully before first deployment; changing Private Service Access ranges later can require rebuilding dependent resources."
+  description = "Prefix length for the Private Service Access range used by Cloud SQL and Memorystore (when create_vpc is true). Valid values are 8 through 24: lower prefix lengths create larger ranges, while higher prefix lengths create smaller ranges. Smaller ranges are supported, but choose the size based on networking requirements after discussing with your Braintrust architecture team because they reduce future expansion headroom. Choose this carefully before first deployment; changing Private Service Access ranges later can require rebuilding dependent resources."
   type        = number
   default     = 16
 
@@ -309,13 +309,13 @@ variable "gke_pods_ipv4_cidr_block" {
 
 variable "gke_pods_secondary_range_name" {
   type        = string
-  description = "Optional name of an existing subnet secondary range to use for GKE Pod IPs. Cannot be set with gke_pods_ipv4_cidr_block. Use this when you want GKE to consume a pre-planned secondary range."
+  description = "Optional name of a secondary range that already exists on the selected subnet for GKE Pod IPs. This variable does not create the range. Cannot be set with gke_pods_ipv4_cidr_block."
   default     = null
 }
 
 variable "gke_services_ipv4_cidr_block" {
   type        = string
-  description = "Optional CIDR block or netmask size for GKE Service IPs. For example, '10.30.0.0/22' or '/22'. Cannot be set with gke_services_secondary_range_name. Choose this carefully before first deployment; changing GKE secondary ranges later is disruptive."
+  description = "Optional CIDR block or netmask size for GKE Service IPs. Most deployments should leave this unset unless they intentionally need a custom Service CIDR. For example, '10.30.0.0/22' or '/22'. Cannot be set with gke_services_secondary_range_name. Choose this carefully before first deployment; changing GKE secondary ranges later is disruptive."
   default     = null
 
   validation {
@@ -326,7 +326,7 @@ variable "gke_services_ipv4_cidr_block" {
 
 variable "gke_services_secondary_range_name" {
   type        = string
-  description = "Optional name of an existing subnet secondary range to use for GKE Service IPs. Cannot be set with gke_services_ipv4_cidr_block. Use this when you want GKE to consume a pre-planned secondary range."
+  description = "Optional name of a secondary range that already exists on the selected subnet for GKE Service IPs. This variable does not create the range. Most deployments should leave this unset unless they intentionally need a custom Service CIDR. Cannot be set with gke_services_ipv4_cidr_block."
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,23 @@ variable "subnet_cidr_range" {
   default     = "10.0.0.0/24"
 }
 
+variable "private_service_access_prefix_length" {
+  description = "Prefix length for the Private Service Access range used by Cloud SQL and Memorystore (when create_vpc is true). Must be 24 or lower, where lower values create larger ranges. Choose this carefully before first deployment; changing Private Service Access ranges later can require rebuilding dependent resources."
+  type        = number
+  default     = 16
+
+  validation {
+    condition     = var.private_service_access_prefix_length >= 8 && var.private_service_access_prefix_length <= 24
+    error_message = "`private_service_access_prefix_length` must be between 8 and 24 inclusive."
+  }
+}
+
+variable "private_service_access_address" {
+  description = "Optional starting address for the Private Service Access range used by Cloud SQL and Memorystore (when create_vpc is true). If null, Google selects an available range. Set this when you need to avoid overlap with existing VPCs, peering, or corporate networks."
+  type        = string
+  default     = null
+}
+
 variable "existing_network_self_link" {
   description = "Self link of an existing VPC network (required when create_vpc is false)."
   type        = string
@@ -277,6 +294,40 @@ variable "gke_control_plane_cidr" {
   type        = string
   description = "The CIDR block for the GKE control plane."
   default     = "10.0.1.0/28"
+}
+
+variable "gke_pods_ipv4_cidr_block" {
+  type        = string
+  description = "Optional CIDR block or netmask size for GKE Pod IPs. For example, '10.20.0.0/20' or '/20'. Cannot be set with gke_pods_secondary_range_name. Choose this carefully before first deployment; changing GKE secondary ranges later is disruptive."
+  default     = null
+
+  validation {
+    condition     = var.gke_pods_ipv4_cidr_block == null || var.gke_pods_secondary_range_name == null
+    error_message = "`gke_pods_ipv4_cidr_block` cannot be set when `gke_pods_secondary_range_name` is set."
+  }
+}
+
+variable "gke_pods_secondary_range_name" {
+  type        = string
+  description = "Optional name of an existing subnet secondary range to use for GKE Pod IPs. Cannot be set with gke_pods_ipv4_cidr_block. Use this when you want GKE to consume a pre-planned secondary range."
+  default     = null
+}
+
+variable "gke_services_ipv4_cidr_block" {
+  type        = string
+  description = "Optional CIDR block or netmask size for GKE Service IPs. For example, '10.30.0.0/22' or '/22'. Cannot be set with gke_services_secondary_range_name. Choose this carefully before first deployment; changing GKE secondary ranges later is disruptive."
+  default     = null
+
+  validation {
+    condition     = var.gke_services_ipv4_cidr_block == null || var.gke_services_secondary_range_name == null
+    error_message = "`gke_services_ipv4_cidr_block` cannot be set when `gke_services_secondary_range_name` is set."
+  }
+}
+
+variable "gke_services_secondary_range_name" {
+  type        = string
+  description = "Optional name of an existing subnet secondary range to use for GKE Service IPs. Cannot be set with gke_services_ipv4_cidr_block. Use this when you want GKE to consume a pre-planned secondary range."
+  default     = null
 }
 
 variable "gke_control_plane_authorized_cidrs" {


### PR DESCRIPTION
Adds optional variables for customizing the GKE pod/service IP ranges and the Private Service Access range used by Cloud SQL and Memorystore. This helps customers fit multiple Braintrust data planes into a planned GCP address space or avoid conflicts with existing peered/corporate networks.

Existing defaults are preserved, so deployments that do not set these variables should see no behavior change.