### PR TITLE
Expose data plane URL-security outputs

### DIFF
--- a/examples/braintrust-data-plane/README.md
+++ b/examples/braintrust-data-plane/README.md
@@ -75,6 +75,25 @@ Once the Terraform has been deployed, there are several steps that will need to 
 
     Review the [helm chart](https://github.com/braintrustdata/helm) to deploy Braintrust on the newly deployed GKE cluster.
 
+    Optional Braintrust data plane URL-security settings can also be configured through Terraform variables. If you set any of these variables, use the corresponding Terraform outputs to read the normalized values:
+
+    ```shell
+    terraform output -raw braintrust_data_plane_unsafe_url_request_mode
+    terraform output -raw braintrust_data_plane_url_security_dns_servers
+    terraform output -raw braintrust_data_plane_url_security_allow_cidrs
+    ```
+
+    Then add only the non-empty values under `api` in `helm-values.yaml`:
+
+    ```yaml
+    api:
+      unsafeUrlRequestMode: "reject"
+      urlSecurityDnsServers: "1.1.1.1,8.8.8.8"
+      urlSecurityAllowCidrs: "10.0.0.0/8,192.168.0.0/16"
+    ```
+
+    Leave these settings unset or empty to omit the corresponding data plane URL-security config. `unsafeUrlRequestMode` then uses the application default of `warn`.
+
 1. Accessing the API
 
     The dataplane requires a HTTPS connection to the API pods. This connection will require a valid HTTPS certificate that is trusted by the clients connecting to the data plane. Google doesn't have a native service that provides managed DNS & Managed SSL certificates like AWS CloudFront or Azure Front Door. There are a several ways to provide a DNS name with a SSL certificate however.

--- a/examples/braintrust-data-plane/main.tf
+++ b/examples/braintrust-data-plane/main.tf
@@ -62,4 +62,10 @@ module "braintrust-data-plane" {
   ### Advanced configuration
   # gcs_additional_allowed_origins = []
 
+  # Optional Braintrust data plane URL-security config. Leave unset or empty to omit these
+  # values. When unsafe_url_request_mode is omitted, the application defaults to warn.
+  # unsafe_url_request_mode  = "reject"
+  # url_security_dns_servers = "1.1.1.1,8.8.8.8"
+  # url_security_allow_cidrs = "10.0.0.0/8,192.168.0.0/16"
+
 }

--- a/examples/braintrust-data-plane/outputs.tf
+++ b/examples/braintrust-data-plane/outputs.tf
@@ -24,6 +24,18 @@ output "brainstore_service_account" {
   value = module.braintrust-data-plane.brainstore_service_account
 }
 
+output "braintrust_data_plane_unsafe_url_request_mode" {
+  value = module.braintrust-data-plane.braintrust_data_plane_unsafe_url_request_mode
+}
+
+output "braintrust_data_plane_url_security_dns_servers" {
+  value = module.braintrust-data-plane.braintrust_data_plane_url_security_dns_servers
+}
+
+output "braintrust_data_plane_url_security_allow_cidrs" {
+  value = module.braintrust-data-plane.braintrust_data_plane_url_security_allow_cidrs
+}
+
 output "postgres_instance_name" {
   value = module.braintrust-data-plane.postgres_instance_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,6 +32,22 @@ output "braintrust_hmac_secret" {
 }
 
 #----------------------------------------------------------------------------------------------
+# Braintrust data plane
+#----------------------------------------------------------------------------------------------
+
+output "braintrust_data_plane_unsafe_url_request_mode" {
+  value = lower(trimspace(var.unsafe_url_request_mode))
+}
+
+output "braintrust_data_plane_url_security_dns_servers" {
+  value = trimspace(var.url_security_dns_servers)
+}
+
+output "braintrust_data_plane_url_security_allow_cidrs" {
+  value = trimspace(var.url_security_allow_cidrs)
+}
+
+#----------------------------------------------------------------------------------------------
 # Database
 #----------------------------------------------------------------------------------------------
 
@@ -48,7 +64,8 @@ output "postgres_username" {
 }
 
 output "postgres_password" {
-  value = module.database.postgres_password
+  value     = module.database.postgres_password
+  sensitive = true
 }
 
 #----------------------------------------------------------------------------------------------
@@ -68,5 +85,6 @@ output "redis_server_ca_certs" {
 }
 
 output "redis_auth_string" {
-  value = module.redis.redis_auth_string
+  value     = module.redis.redis_auth_string
+  sensitive = true
 }

--- a/tests/data_plane_url_security_outputs.tftest.hcl
+++ b/tests/data_plane_url_security_outputs.tftest.hcl
@@ -1,0 +1,80 @@
+override_module {
+  target = module.kms
+  outputs = {
+    kms_key_id = "projects/test/locations/us/keyRings/test/cryptoKeys/test"
+  }
+}
+
+override_module {
+  target = module.database
+  outputs = {
+    postgres_instance_name = "braintrust-postgres"
+    postgres_instance_ip   = "10.0.0.2"
+    postgres_username      = "braintrust"
+    postgres_password      = "test-password"
+  }
+}
+
+override_module {
+  target = module.redis
+  outputs = {
+    redis_instance_port   = 6379
+    redis_instance_host   = "10.0.0.3"
+    redis_server_ca_certs = []
+    redis_auth_string     = "test-auth"
+  }
+}
+
+override_module {
+  target = module.storage
+  outputs = {
+    api_bucket_name        = "braintrust-api"
+    brainstore_bucket_name = "braintrust-brainstore"
+  }
+}
+
+override_module {
+  target = module.gke-iam
+  outputs = {
+    braintrust_service_account = "braintrust@test.iam.gserviceaccount.com"
+    brainstore_service_account = "brainstore@test.iam.gserviceaccount.com"
+    braintrust_hmac_access_id  = "access-id"
+    braintrust_hmac_secret     = "secret"
+  }
+}
+
+variables {
+  deployment_name            = "braintrust"
+  deploy_gke_cluster         = false
+  create_vpc                 = false
+  existing_network_self_link = "projects/test-project/global/networks/braintrust"
+  existing_subnet_self_link  = "projects/test-project/regions/us-central1/subnetworks/braintrust"
+}
+
+run "default_url_security_outputs_are_empty" {
+  command = plan
+
+  assert {
+    condition     = output.braintrust_data_plane_unsafe_url_request_mode == "" && output.braintrust_data_plane_url_security_dns_servers == "" && output.braintrust_data_plane_url_security_allow_cidrs == ""
+    error_message = "Empty URL-security inputs should produce empty Braintrust data plane outputs."
+  }
+}
+
+run "configured_url_security_outputs_are_normalized" {
+  command = plan
+
+  variables {
+    unsafe_url_request_mode  = " reject "
+    url_security_dns_servers = " 1.1.1.1,8.8.8.8 "
+    url_security_allow_cidrs = " 10.0.0.0/8,192.168.0.0/16 "
+  }
+
+  assert {
+    condition = alltrue([
+      output.braintrust_data_plane_unsafe_url_request_mode == "reject",
+      output.braintrust_data_plane_url_security_dns_servers == "1.1.1.1,8.8.8.8",
+      output.braintrust_data_plane_url_security_allow_cidrs == "10.0.0.0/8,192.168.0.0/16",
+    ])
+    error_message = "Non-empty URL-security inputs should be normalized in individual Braintrust data plane outputs."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -383,6 +383,35 @@ variable "gke_maintenance_window" {
 }
 
 #----------------------------------------------------------------------------------------------
+# Braintrust data plane URL security
+#----------------------------------------------------------------------------------------------
+variable "unsafe_url_request_mode" {
+  description = "Controls how Braintrust backends handle outbound requests to user-supplied URLs that fail URL-security checks, such as URLs resolving to private or reserved IP ranges. Use off to allow, warn to allow with warnings, or reject to block. Leave empty to use the application default of warn."
+  type        = string
+  default     = ""
+  nullable    = false
+
+  validation {
+    condition     = contains(["", "off", "warn", "reject"], trimspace(var.unsafe_url_request_mode))
+    error_message = "unsafe_url_request_mode must be empty or one of: off, warn, reject."
+  }
+}
+
+variable "url_security_dns_servers" {
+  description = "Comma-separated DNS resolver IP addresses Braintrust backends should query when checking user-supplied URLs. Set this to force URL-security validation through trusted resolvers, such as VNet or corporate DNS, before falling back to the host resolver. Leave empty to use the application default resolver behavior."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "url_security_allow_cidrs" {
+  description = "Optional comma-separated CIDR ranges that Braintrust backend URL-security validation may allow even if private or reserved. Hard-blocked metadata, link-local, multicast, unspecified, and future-use ranges remain blocked."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+#----------------------------------------------------------------------------------------------
 # GKE IAM
 #----------------------------------------------------------------------------------------------
 variable "braintrust_kube_namespace" {


### PR DESCRIPTION
### Context

Braintrust data plane deployments need a way to pass optional URL-security settings through the GCP Terraform module without forcing values when the application defaults are sufficient. The unsafe URL request mode should continue to default to `warn` when left unset.

### Description

- Adds optional Terraform variables for Braintrust data plane URL-security mode, DNS resolvers, and allowed CIDRs.
- Exposes normalized individual outputs that downstream deployment configuration can use when values are set.
- Adds Terraform coverage for empty default outputs and normalized non-empty outputs.
- Marks root database and Redis secret outputs as sensitive so Terraform plan/test handling does not treat credential values as plain outputs.
