### PR TITLE
Wait for Private Service Access before creating Cloud SQL and Redis

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,8 @@ module "database" {
   postgres_backup_start_time   = var.postgres_backup_start_time
   postgres_maintenance_window  = var.postgres_maintenance_window
   postgres_deletion_protection = var.postgres_deletion_protection
+
+  depends_on = [module.vpc]
 }
 
 module "redis" {
@@ -40,6 +42,8 @@ module "redis" {
   redis_kms_cmek_id    = module.kms.kms_key_id
   redis_version        = var.redis_version
   redis_memory_size_gb = var.redis_memory_size_gb
+
+  depends_on = [module.vpc]
 }
 
 module "storage" {


### PR DESCRIPTION
This improves first-deploy reliability for the GCP data-plane module.

Cloud SQL and Memorystore use private IP networking, which requires the VPC Private Service Access connection to exist first. In a new project, Terraform can otherwise try to create Cloud SQL or Redis before Google has finished setting up that private services connection, causing first apply failures that say Private Service Access is missing.

This change makes the ordering explicit by having the database and Redis modules wait for the VPC module. It does not change module inputs, resource names, or the deployment architecture.