### PR TITLE
Stabilize first-run GCP BYOC provisioning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,4 +104,7 @@ module "gke-iam" {
   brainstore_gcs_bucket_id         = module.storage.brainstore_bucket_name
   braintrust_hmac_key_enabled      = var.braintrust_hmac_key_enabled
   brainstore_impersonation_targets = var.brainstore_impersonation_targets
+
+  # GKE creates the workload identity pool used by these IAM bindings.
+  depends_on = [module.gke-cluster]
 }

--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,5 @@ module "gke-iam" {
   brainstore_gcs_bucket_id         = module.storage.brainstore_bucket_name
   braintrust_hmac_key_enabled      = var.braintrust_hmac_key_enabled
   brainstore_impersonation_targets = var.brainstore_impersonation_targets
-
-  # GKE creates the workload identity pool used by these IAM bindings.
-  depends_on = [module.gke-cluster]
+  workload_identity_pool           = var.deploy_gke_cluster ? module.gke-cluster[0].workload_identity_pool : "${data.google_project.current.project_id}.svc.id.goog"
 }

--- a/managed-byoc/README.md
+++ b/managed-byoc/README.md
@@ -29,6 +29,7 @@ Braintrust deploys the data plane.
 The standard bootstrap creates or mirrors:
 
 - APIs enabled from `services.json`.
+- Cloud Storage service agent initialized for CMEK-backed GCS buckets.
 - Deployment service account:
   `braintrust-deploy@<project-id>.iam.gserviceaccount.com`.
 - Support service account:
@@ -94,7 +95,13 @@ Options:
 
 If the customer mirrors bootstrap with their own provisioning process, use
 `setup.sh`, `services.json`, `deployment-roles.json`, and `support-roles.json`
-as the source of truth for the required end state.
+as the source of truth for the required end state. The provisioning process must
+also initialize the Cloud Storage service agent for the project; `setup.sh` does
+this with:
+
+```bash
+gcloud storage service-agent --project <gcp-project-id>
+```
 
 The script is safe to re-run. It skips existing service accounts, re-applies IAM
 bindings idempotently, and only adds a new Brainstore license secret version if

--- a/managed-byoc/setup.sh
+++ b/managed-byoc/setup.sh
@@ -278,34 +278,46 @@ create_or_update_license_secret() {
   echo "    Added new secret version."
 }
 
+ensure_gcs_service_agent() {
+  echo ">>> Ensuring Cloud Storage service agent exists..."
+  run gcloud storage service-agent --project="$PROJECT_ID" >/dev/null
+  echo "    Done."
+}
+
 # -----------------------------------------------------------------------------
-# Step 2: Create service accounts
+# Step 2: Ensure Google-managed service agents
+# -----------------------------------------------------------------------------
+ensure_gcs_service_agent
+echo ""
+
+# -----------------------------------------------------------------------------
+# Step 3: Create service accounts
 # -----------------------------------------------------------------------------
 create_service_account "$DEPLOY_SA_NAME" "$DEPLOY_SA_EMAIL" "Braintrust Deployment"
 create_service_account "$SUPPORT_SA_NAME" "$SUPPORT_SA_EMAIL" "Braintrust Support"
 echo ""
 
 # -----------------------------------------------------------------------------
-# Step 3: Grant project-level IAM roles
+# Step 4: Grant project-level IAM roles
 # -----------------------------------------------------------------------------
 grant_project_roles "serviceAccount:$DEPLOY_SA_EMAIL" "$DEPLOY_SA_EMAIL" "${DEPLOYMENT_ROLES[@]}"
 grant_project_roles "serviceAccount:$SUPPORT_SA_EMAIL" "$SUPPORT_SA_EMAIL" "${SUPPORT_ROLES[@]}"
 echo ""
 
 # -----------------------------------------------------------------------------
-# Step 4: Create or update Brainstore license secret
+# Step 5: Create or update Brainstore license secret
 # -----------------------------------------------------------------------------
 create_or_update_license_secret
 echo ""
 
 # -----------------------------------------------------------------------------
-# Step 5: Grant impersonation to Braintrust support
+# Step 6: Grant impersonation to Braintrust support
 # -----------------------------------------------------------------------------
 grant_service_account_impersonation "$SUPPORT_SA_EMAIL" "group:$SUPPORT_GROUP" "$SUPPORT_GROUP"
 echo ""
 
 # -----------------------------------------------------------------------------
-# Step 6: Grant impersonation to Braintrust automation
+# Step 7: Grant impersonation to Braintrust automation
 # This allows the Braintrust automation identity to impersonate the customer
 # deployment service account. The AWS-to-GCP WIF bridge itself is maintained in
 # the Braintrust-owned braintrust-byoc-management project, not this project.

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -96,7 +96,7 @@ resource "google_container_cluster" "braintrust_autopilot" {
   logging_service = "logging.googleapis.com/kubernetes"
 
   database_encryption {
-    state    = "ENCRYPTED"
+    state    = "ALL_OBJECTS_ENCRYPTION_ENABLED"
     key_name = var.gke_kms_cmek_id
   }
 

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -96,7 +96,7 @@ resource "google_container_cluster" "braintrust_autopilot" {
   logging_service = "logging.googleapis.com/kubernetes"
 
   database_encryption {
-    state    = "ALL_OBJECTS_ENCRYPTION_ENABLED"
+    state    = "ENCRYPTED"
     key_name = var.gke_kms_cmek_id
   }
 
@@ -122,6 +122,14 @@ resource "google_container_cluster" "braintrust_autopilot" {
     google_kms_crypto_key_iam_member.gke_cluster_cmek,
     google_kms_crypto_key_iam_member.gke_compute_cmek
   ]
+
+  lifecycle {
+    # GKE Autopilot may report ALL_OBJECTS_ENCRYPTION_ENABLED after create, but
+    # the Terraform provider currently accepts only ENCRYPTED/DECRYPTED as input.
+    ignore_changes = [
+      database_encryption[0].state,
+    ]
+  }
 }
 
 #----------------------------------------------------------------------------------------------

--- a/modules/gke-cluster/output.tf
+++ b/modules/gke-cluster/output.tf
@@ -13,3 +13,8 @@ output "gke_autopilot_cluster_master_version" {
   value       = google_container_cluster.braintrust_autopilot.master_version
   description = "Master version of the autopilot cluster (null if not enabled)"
 }
+
+output "workload_identity_pool" {
+  value       = google_container_cluster.braintrust_autopilot.workload_identity_config[0].workload_pool
+  description = "Workload Identity pool for Kubernetes service account IAM bindings."
+}

--- a/modules/gke-iam/main.tf
+++ b/modules/gke-iam/main.tf
@@ -1,10 +1,4 @@
 #----------------------------------------------------------------------------------------------
-# Common
-#----------------------------------------------------------------------------------------------
-
-data "google_project" "current" {}
-
-#----------------------------------------------------------------------------------------------
 # Braintrust service account
 #----------------------------------------------------------------------------------------------
 resource "google_service_account" "braintrust" {
@@ -25,7 +19,7 @@ resource "google_service_account_iam_binding" "braintrust_workload_identity" {
   role               = "roles/iam.workloadIdentityUser"
 
   members = [
-    "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.braintrust_kube_svc_account}]"
+    "serviceAccount:${var.workload_identity_pool}[${var.braintrust_kube_namespace}/${var.braintrust_kube_svc_account}]"
   ]
 }
 
@@ -89,8 +83,8 @@ resource "google_service_account_iam_binding" "brainstore_workload_identity" {
   role               = "roles/iam.workloadIdentityUser"
 
   members = [
-    "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.brainstore_kube_svc_account}]", # brainstore pods
-    "serviceAccount:${data.google_project.current.project_id}.svc.id.goog[${var.braintrust_kube_namespace}/${var.braintrust_kube_svc_account}]", # API pod(s)
+    "serviceAccount:${var.workload_identity_pool}[${var.braintrust_kube_namespace}/${var.brainstore_kube_svc_account}]", # brainstore pods
+    "serviceAccount:${var.workload_identity_pool}[${var.braintrust_kube_namespace}/${var.braintrust_kube_svc_account}]", # API pod(s)
   ]
 }
 

--- a/modules/gke-iam/variables.tf
+++ b/modules/gke-iam/variables.tf
@@ -27,6 +27,11 @@ variable "brainstore_kube_svc_account" {
   default     = "brainstore"
 }
 
+variable "workload_identity_pool" {
+  type        = string
+  description = "GKE Workload Identity pool used for Kubernetes service account IAM bindings, typically <project_id>.svc.id.goog."
+}
+
 variable "braintrust_api_bucket_id" {
   type        = string
   description = "The ID of the GCS bucket for Braintrust API (contains code-bundle and brainstore-cache paths)."

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -20,6 +20,10 @@ data "google_project" "current" {}
 
 data "google_client_config" "current" {}
 
+data "google_storage_project_service_account" "gcs" {
+  project = data.google_project.current.project_id
+}
+
 resource "random_id" "gcs_suffix" {
   byte_length = 4
 }
@@ -219,15 +223,8 @@ resource "google_storage_bucket" "api" {
   ]
 }
 
-#----------------------------------------------------------------------------------------------
-# GCS KMS CMEK
-#----------------------------------------------------------------------------------------------
-locals {
-  gcs_service_account_email = "service-${data.google_project.current.number}@gs-project-accounts.iam.gserviceaccount.com"
-}
-
 resource "google_kms_crypto_key_iam_member" "gcp_project_gcs_cmek" {
   crypto_key_id = var.gcs_kms_cmek_id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:${local.gcs_service_account_email}"
+  member        = "serviceAccount:${data.google_storage_project_service_account.gcs.email_address}"
 }


### PR DESCRIPTION
Adds first-run stability fixes for GCP BYOC deployments.

- Initializes the Cloud Storage service agent during managed BYOC bootstrap so CMEK-backed GCS buckets can be provisioned reliably in fresh customer projects
- Uses `google_storage_project_service_account` instead of constructing the GCS service-agent email manually
- Wires GKE Workload Identity IAM bindings from the actual cluster workload pool output, avoiding timing/readback issues during first apply
- Ignores GKE Autopilot’s normalized `database_encryption.state` readback to avoid Terraform drift when GKE reports a more specific encryption state than the provider accepts as input
- Updates the managed BYOC bootstrap script and README to call out the Cloud Storage service-agent requirement

Backward compatibility:
- No breaking changes
- No existing inputs or resources are removed or renamed
- Existing deployments should continue using the same module interface